### PR TITLE
Updated to docker 1.13.1 and compose 1.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ LABEL org.label-schema.vendor="vfarcic" \
     org.label-schema.build-date=$build_date
 
 ENV "SWARM_CLIENT_VERSION=2.2" \
-    "DOCKER_COMPOSE_VERSION=1.11.1" \
+    "DOCKER_COMPOSE_VERSION=1.11.2" \
     "COMMAND_OPTIONS="
 
 RUN adduser -G root -D jenkins \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.13
+FROM docker:1.13.1
 
 MAINTAINER Viktor Farcic <viktor@farcic.com>
 
@@ -21,7 +21,7 @@ LABEL org.label-schema.vendor="vfarcic" \
     org.label-schema.build-date=$build_date
 
 ENV "SWARM_CLIENT_VERSION=2.2" \
-    "DOCKER_COMPOSE_VERSION=1.10.1" \
+    "DOCKER_COMPOSE_VERSION=1.11.1" \
     "COMMAND_OPTIONS="
 
 RUN adduser -G root -D jenkins \


### PR DESCRIPTION
There's a bug in 1.13.0 when deploying stacks using the `docker stack deploy XXX` command: `Error response from daemon: rpc error: code = 2 desc = changing network in service is not supported`

There's a bug in compose 1.11.0, it does not recognise the compose files 'v3.1' version as valid.