### PR TITLE
Manage username and password with Docker Secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,13 @@ LABEL org.label-schema.vendor="vfarcic" \
     org.label-schema.schema-version="1.0" \
     org.label-schema.build-date=$build_date
 
-ENV "SWARM_CLIENT_VERSION=2.2" \
+ENV "SWARM_CLIENT_VERSION=3.3" \
     "DOCKER_COMPOSE_VERSION=1.11.2" \
     "COMMAND_OPTIONS="
 
 RUN adduser -G root -D jenkins \
  && apk --update --no-cache add openjdk8-jre python py-pip git openssh \
- && wget -q https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${SWARM_CLIENT_VERSION}/swarm-client-${SWARM_CLIENT_VERSION}-jar-with-dependencies.jar -P /home/jenkins/ \
+ && wget -q https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${SWARM_CLIENT_VERSION}/swarm-client-${SWARM_CLIENT_VERSION}.jar -P /home/jenkins/ \
  && pip install docker-compose
 
 COPY run.sh /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ LABEL org.label-schema.vendor="vfarcic" \
 
 ENV "SWARM_CLIENT_VERSION=3.3" \
     "DOCKER_COMPOSE_VERSION=1.11.2" \
-    "COMMAND_OPTIONS="
+    "COMMAND_OPTIONS=" \
+    "USER_NAME_SECRET=" \
+    "PASSWORD_SECRET="
 
 RUN adduser -G root -D jenkins \
  && apk --update --no-cache add openjdk8-jre python py-pip git openssh \

--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ Usage
 -----
 
 The environment variable COMMAND_OPTIONS has to be specified with non-empty value, which is a combination of all swarm client options you need. Please refer to this [Swarm Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Swarm+Plugin) for all available options.
+
+For the username and password, it makes use of [Docker Secrets](https://docs.docker.com/engine/swarm/secrets/).
+You can run this service as follows:
+
+```bash
+docker service create --name $JENKINS_AGENT_SERVICE \
+    --secret source=jenkins-master1-usr,target=jks-admin-usr \
+    --secret source=jenkins-master1-pass,target=jks-admin-pass \
+    -e USER_NAME_SECRET="/run/secrets/jks-admin-usr"\
+    -e PASSWORD_SECRET="/run/secrets/jks-admin-pass"\
+    -e COMMAND_OPTIONS="-master http://${MASTER_URL}:8080 \
+    -labels 'docker' -executors 3
+    -fsroot /tmp" \
+    --network $NETWORK \
+    --mode global \
+    --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock" \
+    --mount "type=bind,source=/tmp,target=/tmp/workspace" \
+    vfarcic/jenkins-swarm-agent
+```

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-java -jar /home/jenkins/swarm-client-${SWARM_CLIENT_VERSION}-jar-with-dependencies.jar ${COMMAND_OPTIONS}
+java -jar /home/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar ${COMMAND_OPTIONS}

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,3 @@
-java -jar /home/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar ${COMMAND_OPTIONS}
+read PSS < ${PASSWORD_SECRET}
+read USR < ${USER_NAME_SECRET}
+java -jar /home/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar ${COMMAND_OPTIONS} -username $USR -password $PSS


### PR DESCRIPTION
Assuming we only use this in an Docker Swarm cluster only.
If thats not the case, maybe this should be a separate branch so there's a separate tag for this usecase.

Updated the client version to 3.3, as it has some good improvements over 2.2.
For me 3.4 didn't work without the -sslFingerprints tags, so kept it at 3.3.