### PR TITLE
Security improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM docker:17.11
 
 MAINTAINER Viktor Farcic <viktor@farcic.com>
 
-ARG "version=0.2.0"
-ARG "build_date=unknown"
-ARG "commit_hash=unknown"
-ARG "vcs_url=unknown"
-ARG "vcs_branch=unknown"
+ARG version="0.2.0"
+ARG build_date="unknown"
+ARG commit_hash="unknown"
+ARG vcs_url="unknown"
+ARG vcs_branch="unknown"
 
 LABEL org.label-schema.vendor="vfarcic" \
     org.label-schema.name="jenkins-swarm-agent" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV SWARM_CLIENT_VERSION="3.6" \
     USER_NAME_SECRET="" \
     PASSWORD_SECRET=""
 
-RUN adduser -G root -D jenkins && \
+RUN adduser -D jenkins && \
     apk --update --no-cache add openjdk8-jre python py-pip git openssh ca-certificates openssl && \
     wget -q https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${SWARM_CLIENT_VERSION}/swarm-client-${SWARM_CLIENT_VERSION}.jar -P /home/jenkins/ && \
     pip install docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     image: vfarcic/jenkins-swarm-agent
     privileged: true
     environment:
-      - COMMAND_OPTIONS=-master ${JENKINS_ADDRESS} -username ${USER} -password ${PASSWORD}
+      - COMMAND_OPTIONS=-master ${JENKINS_ADDRESS} -username ${USER} -passwordEnvVariable PASSWORD_ENVVAR
+      - PASSWORD_ENVVAR=${PASSWORD}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /workspace:/workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
   jenkins-agent:
     container_name: jenkins-agent
     image: vfarcic/jenkins-swarm-agent
-    privileged: true
     environment:
       - COMMAND_OPTIONS=-master ${JENKINS_ADDRESS} -username ${USER} -passwordEnvVariable PASSWORD_ENVVAR
       - PASSWORD_ENVVAR=${PASSWORD}

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,8 @@ fi
 
 if [ -f "${PASSWORD_SECRET}" ]; then
     read PSS < ${PASSWORD_SECRET}
-    COMMAND_OPTIONS="${COMMAND_OPTIONS} -password $PSS"
+    export PSS
+    COMMAND_OPTIONS="${COMMAND_OPTIONS} -passwordEnvVariable PSS"
 fi
 
 java -jar /home/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar ${COMMAND_OPTIONS}

--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,10 @@ if [ -f "${PASSWORD_SECRET}" ]; then
     COMMAND_OPTIONS="${COMMAND_OPTIONS} -passwordEnvVariable PSS"
 fi
 
-java -jar /home/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar ${COMMAND_OPTIONS}
+GROUP=$(stat -c %G /var/run/docker.sock)
+if [ ! $(grep ^$GROUP: /etc/group) ]; then
+    addgroup -G $(stat -c %g /var/run/docker.sock) $GROUP
+fi
+adduser jenkins $GROUP
+
+exec su jenkins -c "exec java -jar /home/jenkins/swarm-client-${SWARM_CLIENT_VERSION}.jar ${COMMAND_OPTIONS}"


### PR DESCRIPTION
This addresses part of [Password disclosure with Jenkins Swarm plugin](https://github.com/vfarcic/docker-flow-stacks/issues/15).  It moves the password into an environment variable and run the swarm plugin CLI as a non-root user (that has access to the Docker socket).

Workspace ownership and group will have to be modified to match the `jenkins` user in the swarm-agent container (numeric ID `1000`).